### PR TITLE
Update release.rb

### DIFF
--- a/lib/pod/command/release.rb
+++ b/lib/pod/command/release.rb
@@ -107,6 +107,7 @@ module Pod
           puts "#{"==>".magenta} Tagging repository with version #{"#{version}".green}"
 
           unless system("git tag | grep #{version} > /dev/null")
+            execute "git pull"
             execute "git add -A && git commit -m \"Release #{version}\"", :optional => true
             execute "git tag #{version} -f"
             execute "git push && git push --tags"

--- a/lib/pod/command/release.rb
+++ b/lib/pod/command/release.rb
@@ -108,7 +108,7 @@ module Pod
 
           unless system("git tag | grep #{version} > /dev/null")
             execute "git add -A && git commit -m \"Release #{version}\"", :optional => true
-            execute "git tag #{version}"
+            execute "git tag #{version} -f"
             execute "git push && git push --tags"
           end
 


### PR DESCRIPTION
I am trying to cover a case here: Say the GIT tagging process went through without any issues, but the SDK publish step failed for some reason. So the next time you restart the job, the tagging step will fail as there is TAG with the version already. I am not sure if deleting a tag is a good way to do things. Please review.