### PR TITLE
Search for exact string while looking  up tags

### DIFF
--- a/lib/pod/command/release.rb
+++ b/lib/pod/command/release.rb
@@ -106,7 +106,7 @@ module Pod
           # Create git tag for current version
           puts "#{"==>".magenta} Tagging repository with version #{"#{version}".green}"
 
-          unless system("git tag | grep #{version} > /dev/null")
+          unless system("git tag | grep -x #{version} > /dev/null")
             execute "git pull"
             execute "git add -A && git commit -m \"Release #{version}\"", :optional => true
             execute "git tag #{version} -f"


### PR DESCRIPTION
For example: 
if we are release 6.9.0, and there is a tag 6.9.0-beta1. It will skip the tag process completely and fail downstream.
Having this "-x" option will only try to match the exact string. Please review.